### PR TITLE
fix: add back rules for import/first and import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,6 +65,22 @@ module.exports = {
     // Enforced
     //
     curly: "warn",
+    // Force import first
+    "import/first": "warn",
+    "import/order": [
+      "warn",
+      {
+        groups: ["builtin", "external"],
+        pathGroups: [
+          {
+            pattern: "@epconnect/**",
+            group: "external",
+            position: "after",
+          },
+        ],
+        "newlines-between": "always-and-inside-groups",
+      },
+    ],
     // Set console calls to emit warnings as not enabled by eslint:recommended
     "no-console": "warn",
     // enforce types

--- a/config.json
+++ b/config.json
@@ -18,18 +18,40 @@
     "project": "./tsconfig.json"
   },
   "plugins": [
-    "@typescript-eslint",
     "sonarjs",
     "react-hooks",
     "react",
     "jsx-a11y",
     "import",
-    "flowtype"
+    "flowtype",
+    "@typescript-eslint"
   ],
   "reportUnusedDisableDirectives": true,
   "rules": {
     "curly": [
       "warn"
+    ],
+    "import/first": [
+      "warn"
+    ],
+    "import/order": [
+      "warn",
+      {
+        "groups": [
+          "builtin",
+          "external"
+        ],
+        "pathGroups": [
+          {
+            "pattern": "@epconnect/**",
+            "group": "external",
+            "position": "after"
+          }
+        ],
+        "newlines-between": "always-and-inside-groups",
+        "distinctGroup": true,
+        "warnOnUnassignedImports": false
+      }
     ],
     "no-console": [
       "warn"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-sonarjs": "^0.19.0"
       },
       "devDependencies": {
+        "@types/node": "^16.18.23",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "eslint": "^8.37.0",
         "prettier": "^2.8.7",
@@ -1456,6 +1457,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "16.18.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
+      "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -10519,6 +10526,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "16.18.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
+      "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-sonarjs": "^0.19.0"
   },
   "devDependencies": {
+    "@types/node": "^16.18.23",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "eslint": "^8.37.0",
     "prettier": "^2.8.7",

--- a/sandbox.ts
+++ b/sandbox.ts
@@ -1,6 +1,16 @@
 // A dummy files to test manually rules
+/* eslint-disable no-console */
 
-// eslint-disable-next-line no-console
+import _json5 from "json5";
+
+const first = 0;
+
+// eslint-disable-next-line import/first
+import pkg from "./package.json";
+
+// eslint-disable-next-line import/first, import/order
+import fs from "fs";
+
 console.log("hello");
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -9,8 +19,9 @@ const empty = 1;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let dummy: any;
 
+console.log(fs.readSync);
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const getDummy = (param: unknown) => {
-  // eslint-disable-next-line no-console
-  console.log(`${dummy} and ${param}`);
+  console.log(`${dummy} and ${param} a, ${first}, ${pkg.version}`);
 };


### PR DESCRIPTION
BREAKING CHANGE: import first added back, so breaking from previous version that disabled it implicitely
BREAKING CHANGE: added import ordering