### PR TITLE
feat(ui-components): forbid usage of base mui components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -127,6 +127,82 @@ module.exports = {
         ignoreCase: false,
       },
     ],
+    "no-restricted-imports": [
+      "warn",
+      {
+        paths: [
+          {
+            name: "@mui/material",
+            importNames: [
+              "Table",
+              "Dialog",
+              "Tooltip",
+              "Button",
+              "TextField",
+              "Select",
+              "Switch",
+              "Tab",
+              "Tabs",
+            ],
+            message: "Please import from '@epconnect/mui-components' instead.",
+          },
+          {
+            name: "@mui/material/Table",
+            importNames: ["default"],
+            message:
+              "Please import Table from '@epconnect/mui-components' instead.",
+          },
+          {
+            name: "@mui/material/Dialog",
+            importNames: ["default"],
+            message:
+              "Please import ResponsiveDialog from '@epconnect/mui-components' instead.",
+          },
+          {
+            name: "@mui/material/Tooltip",
+            importNames: ["default"],
+            message:
+              "Please import Tooltip from '@epconnect/mui-components' instead.",
+          },
+          {
+            name: "@mui/material/Button",
+            importNames: ["default"],
+            message:
+              "Please import Button from '@epconnect/mui-components' instead.",
+          },
+          {
+            name: "@mui/material/TextField",
+            importNames: ["default"],
+            message:
+              "Please import TextField from '@epconnect/mui-components' instead.",
+          },
+          {
+            name: "@mui/material/Select",
+            importNames: ["default"],
+            message:
+              "Please import SmartSelector from '@epconnect/mui-components' instead.",
+          },
+          {
+            name: "@mui/material/Switch",
+            importNames: ["default"],
+            message:
+              "Please import SwitchControl from '@epconnect/mui-components' instead.",
+          },
+          {
+            name: "@mui/material/Tab",
+            importNames: ["default"],
+            message:
+              "Please import TabsBar from '@epconnect/mui-components' instead.",
+          },
+          {
+            name: "@mui/material/Tabs",
+            importNames: ["default"],
+            message:
+              "Please import TabsBar from '@epconnect/mui-components' instead.",
+          },
+        ],
+      },
+    ],
   },
   overrides: [
     // Typescript overrides

--- a/config.json
+++ b/config.json
@@ -87,6 +87,91 @@
         "ignoreMemberSort": false
       }
     ],
+    "no-restricted-imports": [
+      "warn",
+      {
+        "paths": [
+          {
+            "name": "@mui/material",
+            "importNames": [
+              "Table",
+              "Dialog",
+              "Tooltip",
+              "Button",
+              "TextField",
+              "Select",
+              "Switch",
+              "Tab",
+              "Tabs"
+            ],
+            "message": "Please import from '@epconnect/mui-components' instead."
+          },
+          {
+            "name": "@mui/material/Table",
+            "importNames": [
+              "default"
+            ],
+            "message": "Please import Table from '@epconnect/mui-components' instead."
+          },
+          {
+            "name": "@mui/material/Dialog",
+            "importNames": [
+              "default"
+            ],
+            "message": "Please import ResponsiveDialog from '@epconnect/mui-components' instead."
+          },
+          {
+            "name": "@mui/material/Tooltip",
+            "importNames": [
+              "default"
+            ],
+            "message": "Please import Tooltip from '@epconnect/mui-components' instead."
+          },
+          {
+            "name": "@mui/material/Button",
+            "importNames": [
+              "default"
+            ],
+            "message": "Please import Button from '@epconnect/mui-components' instead."
+          },
+          {
+            "name": "@mui/material/TextField",
+            "importNames": [
+              "default"
+            ],
+            "message": "Please import TextField from '@epconnect/mui-components' instead."
+          },
+          {
+            "name": "@mui/material/Select",
+            "importNames": [
+              "default"
+            ],
+            "message": "Please import SmartSelector from '@epconnect/mui-components' instead."
+          },
+          {
+            "name": "@mui/material/Switch",
+            "importNames": [
+              "default"
+            ],
+            "message": "Please import SwitchControl from '@epconnect/mui-components' instead."
+          },
+          {
+            "name": "@mui/material/Tab",
+            "importNames": [
+              "default"
+            ],
+            "message": "Please import TabsBar from '@epconnect/mui-components' instead."
+          },
+          {
+            "name": "@mui/material/Tabs",
+            "importNames": [
+              "default"
+            ],
+            "message": "Please import TabsBar from '@epconnect/mui-components' instead."
+          }
+        ]
+      }
+    ],
     "lines-around-comment": [
       0
     ],
@@ -190,6 +275,9 @@
       "off"
     ],
     "linebreak-style": [
+      "off"
+    ],
+    "max-statements-per-line": [
       "off"
     ],
     "multiline-ternary": [
@@ -460,6 +548,9 @@
       "off"
     ],
     "vue/array-bracket-spacing": [
+      "off"
+    ],
+    "vue/array-element-newline": [
       "off"
     ],
     "vue/arrow-spacing": [
@@ -1021,11 +1112,11 @@
     }
   },
   "ignorePatterns": [
-    "build",
-    "coverage",
-    "dist",
-    "doc",
-    "node_modules",
-    "tmp"
+    "/build",
+    "/coverage",
+    "/dist",
+    "/doc",
+    "/node_modules",
+    "/tmp"
   ]
 }


### PR DESCRIPTION
BREAKING CHANGE
Courtesy of Luc Buatois: Add a rule to avoid using generic UI components when dedicated ones already exist.
