### PR TITLE
fix: added no-restricted-imports for lodash and no-namespace warnings

### DIFF
--- a/config.json
+++ b/config.json
@@ -88,10 +88,20 @@
         "ignoreMemberSort": false
       }
     ],
+    "import/no-namespace": [
+      "warn",
+      {
+        "ignore": []
+      }
+    ],
     "no-restricted-imports": [
       "warn",
       {
         "paths": [
+          {
+            "name": "lodash",
+            "message": "Do not import the entire lodash library. Import specific modules, e.g. 'lodash/cloneDeep' or use 'lodash-es'."
+          },
           {
             "name": "@mui/icons-material",
             "message": "Import specific icons from '@mui/icons-material/<IconName>'"


### PR DESCRIPTION
- Added no-restricted-imports rules for lodash to warn on full lodash import
- Added import/no-namespace to warn about imports such as 'import * as _ ...'
